### PR TITLE
[build] use external launch4j config file and override some build specific properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
 			<plugin>
 				<groupId>com.akathist.maven.plugins.launch4j</groupId>
 				<artifactId>launch4j-maven-plugin</artifactId>
-				<version>1.7.14</version>
+				<version>1.7.15</version>
 				<executions>
 					<execution>
 						<id>exe-win</id>
@@ -290,66 +290,18 @@
 							<goal>launch4j</goal>
 						</goals>
 						<configuration>
-							<!--
-								including external launch4j config file and overriding onyl some values is not supported
-								# https://github.com/lukaszlenart/launch4j-maven-plugin/issues/48
-							-->
-							<!--<infile>${project.build.sourceDir}/launch4j-config.xml</infile>-->
+							<!-- use external launch4j configuration file -->
+							<infile>${project.build.sourceDir}/launch4j-config.xml</infile>
 
-							<dontWrapJar>false</dontWrapJar>
-							<headerType>gui</headerType>
+							<!-- override some build specific properties -->
 							<jar>${project.build.directory}/${my.finalJarName}.jar</jar>
 							<outfile>${project.build.directory}/${my.finalShortName}.exe</outfile>
-							<errTitle />
-							<cmdLine />
-							<chdir />
-							<priority>normal</priority>
-							<downloadUrl>https://www.java.com/download/</downloadUrl>
-							<supportUrl />
-							<stayAlive>true</stayAlive>
-							<restartOnCrash>false</restartOnCrash>
-							<manifest />
-							<icon>${project.build.icons.sourceDir}/paginaEPUBChecker_512.ico</icon>
-							<singleInstance>
-								<mutexName>${my.finalJarName}</mutexName>
-								<windowTitle>${my.finalShortName}</windowTitle>
-							</singleInstance>
-							<jre>
-								<path />
-								<bundledJre64Bit>false</bundledJre64Bit>
-								<bundledJreAsFallback>false</bundledJreAsFallback>
-								<minVersion>1.7.0</minVersion>
-								<maxVersion />
-								<jdkPreference>preferJre</jdkPreference>
-								<runtimeBits>64/32</runtimeBits>
-							</jre>
-							<splash>
-								<file>${project.build.splash.sourceDir}/SplashScreen_Windows.bmp</file>
-								<waitForWindow>true</waitForWindow>
-								<timeout>60</timeout>
-								<timeoutErr>false</timeoutErr>
-							</splash>
 							<versionInfo>
 								<fileVersion>${my.versionNumber}.0</fileVersion>
 								<txtFileVersion>${my.versionNumber}</txtFileVersion>
 								<productVersion>${my.versionNumber}.0</productVersion>
 								<txtProductVersion>${my.versionNumber}</txtProductVersion>
-								<fileDescription>${my.finalLongName}</fileDescription>
-								<copyright>pagina GmbH, Tuebingen</copyright>
-								<productName>${my.finalLongName}</productName>
-								<companyName>pagina GmbH</companyName>
-								<internalName>${my.finalShortName}</internalName>
-								<originalFilename>${my.finalShortName}.exe</originalFilename>
-								<trademarks />
-								<language>ENGLISH_US</language>
 							</versionInfo>
-							<messages>
-								<startupErr>An error occurred while starting 'pagina EPUB-Checker'. Please contact support.</startupErr>
-								<bundledJreErr>'pagina EPUB-Checker' was configured to use a bundled Java Runtime Environment but the runtime is missing or corrupted. Please contact support.</bundledJreErr>
-								<jreVersionErr>'pagina EPUB-Checker' requires an installed Java Runtime Environment (JRE): min.</jreVersionErr>
-								<launcherErr>The registry refers to a nonexistent Java Runtime Environment (JRE) installation or the runtime is corrupted. 'pagina EPUB-Checker' can't be used. Please contact support.</launcherErr>
-								<instanceAlreadyExistsMsg>Another instance of 'pagina EPUB-Checker' is already running.</instanceAlreadyExistsMsg>
-							</messages>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/build/launch4j-config.xml
+++ b/src/build/launch4j-config.xml
@@ -36,10 +36,10 @@
   <versionInfo>
     <fileVersion>1.7.0.0</fileVersion>
     <txtFileVersion>1.7.0</txtFileVersion>
-    <fileDescription>pagina EPUB-Checker</fileDescription>
-    <copyright>pagina GmbH, Tuebingen</copyright>
     <productVersion>1.7.0.0</productVersion>
     <txtProductVersion>1.7.0</txtProductVersion>
+    <fileDescription>pagina EPUB-Checker</fileDescription>
+    <copyright>pagina GmbH, Tuebingen</copyright>
     <productName>pagina EPUB-Checker</productName>
     <companyName>pagina GmbH</companyName>
     <internalName>EPUB-Checker</internalName>


### PR DESCRIPTION
possible since 1.7.15 through changes committet in https://github.com/lukaszlenart/launch4j-maven-plugin/pull/49

- [x] Mac tests
- [x] Unix CI tests
- [ ] Windows tests (compare old and new EXE files)