### PR TITLE
Release v2.0.1 via GitHub Actions

### DIFF
--- a/.github/workflows/maven-test-build.yml
+++ b/.github/workflows/maven-test-build.yml
@@ -3,6 +3,7 @@
 # - https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 # - https://github.com/actions/setup-java
 # - https://github.com/actions/starter-workflows/edit/master/ci/maven.yml
+# - https://github.com/actions/cache/blob/master/examples.md#java---maven
 
 name: Maven test, build and verify
 
@@ -30,6 +31,14 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+
+    - name: Cache Maven dependencies between builds
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-jdk${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-jdk${{ matrix.java }}-
 
     - name: Build and Verify with Maven on Java ${{ matrix.java }}
       run: mvn -B --show-version -Dmaven.skip.macSigning=true clean verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master --follow-tags --tags
         git fetch --prune
         git checkout development
-        git merge master
+        git merge master --no-ff
         git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:development
 
     - name: Archive Mac DiskImage distributable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,14 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
 
+    - name: Cache Maven dependencies between builds
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
     - name: Build the Java App and the native wrappers with Maven and codesign and notarize the Mac App
       run: |
         mvn -B --show-version -Darguments=-Dmaven.skip.macSigning=false clean release:clean release:prepare

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   release:
-
     runs-on: macos-latest
-
+    env:
+      MAVEN_VERSIONS_PLUGIN: org.codehaus.mojo:versions-maven-plugin:2.7
     steps:
-
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
@@ -62,19 +61,28 @@ jobs:
 
     - name: Build the Java App and the native wrappers with Maven and codesign and notarize the Mac App
       run: |
-        mvn -B --show-version -Darguments=-Dmaven.skip.macSigning=false clean release:clean release:prepare
+        mvn -B ${MAVEN_VERSIONS_PLUGIN}:set -DremoveSnapshot=true -DgenerateBackupPoms=false
+        export MAVEN_PROJECT_VERSION=$(mvn help:evaluate -Dexpression="project.version" -q -DforceStdout)
+        mvn -B --show-version -Dmaven.skip.macSigning=false clean package
+        git commit -a -m "release version ${MAVEN_PROJECT_VERSION}"
+        git tag v${MAVEN_PROJECT_VERSION}
 
-    - name: Push maven-release-plugin changes
-      # does not work on Mac: https://github.com/ad-m/github-push-action/issues/51
+    - name: Push changes at pom.xml to master
+      # 'github-push-action' does not work on 'macos-latest': https://github.com/ad-m/github-push-action/issues/51
       #uses: ad-m/github-push-action@v0.5.0
       #with:
       #  tags: true
       #  github_token: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master --follow-tags --tags
+
+    - name: Increment maven project version on development branch
+      run: |
         git fetch --prune
-        git checkout development
-        git merge master --no-ff
+        git checkout -f development
+        git merge --no-ff master
+        mvn -B ${MAVEN_VERSIONS_PLUGIN}:set -DnextSnapshot=true -DgenerateBackupPoms=false
+        git commit -a -m "prepare for next development iteration"
         git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:development
 
     - name: Archive Mac DiskImage distributable

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ buildConfig/lib/
 .settings/
 .idea
 EPUB-Checker.iml
+.vscode/
 
 # maven stuff
 target/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ License information
 Our app and code and all the java sources in `de.paginagmbh.*` are licensed under the terms of the  [GNU General Public License v2.0](http://choosealicense.com/licenses/gpl-2.0/) unless the code comments specify the contrary.
 
 We use the following Java libraries to build our GUI wrapper around *EPUBCheck*:
-* [EPUBCheck](https://github.com/w3c/epubcheck) 4.2.2 (*3-Clause BSD License*)
+* [EPUBCheck](https://github.com/w3c/epubcheck) 4.2.4 (*3-Clause BSD License*)
 * [JSON RPC](http://mvnrepository.com/artifact/com.metaparadigm/json-rpc/1.0) 1.0 (*Apache License 2.0*)
 * [Apple Java Extensions](http://mvnrepository.com/artifact/com.apple/AppleJavaExtensions/1.4) 1.4 (*Apple License*)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pagina EPUB-Checker
 
 ![Java CI with Maven](https://github.com/paginagmbh/EPUB-Checker/workflows/Java%20CI%20with%20Maven/badge.svg)
 
-Standalone "EPUB-Checker" application for Windows, macOS and Linux.
+Standalone "EPUBCheck" application for Windows, macOS and Linux.
 
 With the pagina EPUB-Checker one can easily validate eBooks in the EPUB format. The test mechanisms of the EPUB-Checker are based on the official open-source [EPUBCheck](https://github.com/w3c/epubcheck) EPUB validator.
 
@@ -40,7 +40,7 @@ Download
 
 Please visit our website https://www.pagina.gmbh/produkte/epub-checker/ to download the Windows _EXE_ file, the Mac _App_ or the Linux _JAR_.
 
-This is just the source code repository. You won't find any binary downloads here...
+This is just the source code repository. You won't find any pre-build binaries here...
 
 
 License information
@@ -108,9 +108,9 @@ To be able to submit the App for notarization, you need to copy `src/build/gon-d
 
 DiskImage creation is done with the NodeJS utility [electron-installer-dmg](https://github.com/electron-userland/electron-installer-dmg). It will be installed via NPM if it's missing.
 
-### Build the release
+### Build the release locally
 
-The codesign and notarization step is _skipped by the default_ in the Maven configuration. In order to run it, you need to enable it explicitly with:
+To build the JAR's, the Windows EXE and Mac App and to run the Mac App codesigning and notarization process for distribution _locally,_ you have to enable the _skipped-by-default_ maven task with:
 
 ```
 mvn -Dmaven.skip.macSigning=false clean package

--- a/README.md
+++ b/README.md
@@ -96,21 +96,21 @@ Releasing a new version requires the Mac App to be codesigned and notarized. Thi
 
 *App codesigning*
 
-Codesigning is done with the macOS system tools
+Codesigning is done with the default macOS `codesign` utility
 
 *App notarization*
 
-This is done with the [gon](https://github.com/mitchellh/gon) utility, an excellent wrapper for this job. It will be installed via HomeBrew if missing.
+App notarization is done with [gon](https://github.com/mitchellh/gon), an excellent utility for this job. It will be installed via HomeBrew if it's missing.
 
-To build signed packages, you need to copy `src/build/gon-dmg-config.template.json` to `src/build/gon-dmg-config.json` and fill all empty keys.
+To be able to submit the App for notarization, you need to copy `src/build/gon-dmg-config.template.json` to `src/build/gon-dmg-config.json` and fill the `apple_id` credentials.
 
 *DiskImage creation*
 
-Creating the DiskImage is done with the NodeJS library [electron-installer-dmg](https://github.com/electron-userland/electron-installer-dmg).
+DiskImage creation is done with the NodeJS utility [electron-installer-dmg](https://github.com/electron-userland/electron-installer-dmg). It will be installed via NPM if it's missing.
 
 ### Build the release
 
-Signing is skipped by the default `mvn package` task. In order to sign and notarize, you need to *not skip it* and run:
+The codesign and notarization step is _skipped by the default_ in the Maven configuration. In order to run it, you need to enable it explicitly with:
 
 ```
 mvn -Dmaven.skip.macSigning=false clean package

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ To build the JAR's, the Windows EXE and Mac App and to run the Mac App codesigni
 mvn -Dmaven.skip.macSigning=false clean package
 ```
 
-Or during a `mvn release:prepare` with the `maven-release-plugin`:
 
-```
-mvn -Darguments=-Dmaven.skip.macSigning=false release:clean release:prepare
-```
+### Build & release with GitHub Actions
+
+To build and release with GitHub Actions CI, just merge a _snapshot version_ from `development` to `master`. No need to upgrade the Maven version first or to set a git tag. Just merge to `master` and CI is doing all the hard work (as defined in `.github/workflows/release.yml`).
+
+The release distributables are attached to the GitHub Actions build as build artifacts and can be used for distribution on our download server.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pagina EPUB-Checker
 
 ![Java CI with Maven](https://github.com/paginagmbh/EPUB-Checker/workflows/Java%20CI%20with%20Maven/badge.svg)
 
-Standalone "EPUB-Checker" application for Windows, Mac OS X and Linux.
+Standalone "EPUB-Checker" application for Windows, macOS and Linux.
 
 With the pagina EPUB-Checker one can easily validate eBooks in the EPUB format. The test mechanisms of the EPUB-Checker are based on the official open-source [EPUBCheck](https://github.com/w3c/epubcheck) EPUB validator.
 
@@ -38,7 +38,7 @@ pagina EPUB-Checker doesn't need to be installed and therefore works on portable
 Download
 --------
 
-Please visit our website https://www.pagina.gmbh/produkte/epub-checker/ to download the Windows _EXE_ file, the Mac OS _App_ or the Linux _JAR_.
+Please visit our website https://www.pagina.gmbh/produkte/epub-checker/ to download the Windows _EXE_ file, the Mac _App_ or the Linux _JAR_.
 
 This is just the source code repository. You won't find any binary downloads here...
 
@@ -72,7 +72,7 @@ mvn clean package
 
 from the root directory of this project.
 
-This will build the executables but skip the Mac OS specific codesigning process by default.
+This will build the executables but skip the macOS specific codesigning process by default.
 
 
 ### Build requirements
@@ -84,11 +84,11 @@ This will build the executables but skip the Mac OS specific codesigning process
 Release the app
 ---------------
 
-Releasing a new version requires the Mac OS App to be codesigned and notarized. This can be done from the maven packaging process or during a `mvn release:prepare` call. The additional maven step will run a bash script to sign and notarize the Mac App with our private Apple Developer Certificate. Therefore, this step will only work on our systems or in GitHub Actions CI.
+Releasing a new version requires the Mac App to be codesigned and notarized. This can be done from the maven packaging process or via GitHub Actions CI on the `master` branch. The additional maven step will run a bash script (`src/build/mac-release.sh`) to codesign and notarize the Mac App with our private Apple Developer Certificate. Therefore, this step will only work on our systems or in GitHub Actions CI.
 
 ### Release requirements
 
-* Mac OS X 10.14+
+* macOS 10.14+
 * Java/JDK 8
 * Maven 3.5+
 * NodeJS + npm
@@ -96,7 +96,7 @@ Releasing a new version requires the Mac OS App to be codesigned and notarized. 
 
 *App codesigning*
 
-Codesigning is done with Mac OS system tools
+Codesigning is done with the macOS system tools
 
 *App notarization*
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Codesigning is done with Mac OS system tools
 
 *App notarization*
 
-This is done with the [gon](https://github.com/mitchellh/gon) command, an excellent wrapper for this job. It will be installed via HomeBrew if missing.
+This is done with the [gon](https://github.com/mitchellh/gon) utility, an excellent wrapper for this job. It will be installed via HomeBrew if missing.
 
 To build signed packages, you need to copy `src/build/gon-dmg-config.template.json` to `src/build/gon-dmg-config.json` and fill all empty keys.
 
@@ -113,13 +113,11 @@ Creating the DiskImage is done with the NodeJS library [electron-installer-dmg](
 Signing is skipped by the default `mvn package` task. In order to sign and notarize, you need to *not skip it* and run:
 
 ```
-export APPLE_DEVELOPER_SIGNING_IDENTITY="your.identity"
 mvn -Dmaven.skip.macSigning=false clean package
 ```
 
 Or during a `mvn release:prepare` with the `maven-release-plugin`:
 
 ```
-export APPLE_DEVELOPER_SIGNING_IDENTITY="your.identity"
 mvn -Darguments=-Dmaven.skip.macSigning=false release:clean release:prepare
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.w3c</groupId>
 			<artifactId>epubcheck</artifactId>
-			<version>4.2.2</version>
+			<version>4.2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.metaparadigm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -391,8 +391,8 @@
 			</plugin>
 
 			<!--
-				codesign and verify the Mac App
-				# skip with -Dmaven.skip.macSigning=true
+				codesign and notarize the Mac App
+				skipped by default. enable with -Dmaven.skip.macSigning=false
 			-->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -425,24 +425,6 @@
 				</executions>
 			</plugin>
 
-			<!-- maven-release-plugin -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>3.0.0-M1</version>
-				<configuration>
-					<tagNameFormat>v@{project.version}</tagNameFormat>
-					<scmReleaseCommitComment>@{prefix} Release @{releaseLabel}</scmReleaseCommitComment>
-					<pushChanges>False</pushChanges>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.scm</groupId>
-						<artifactId>maven-scm-provider-gitexe</artifactId>
-						<version>1.11.2</version>
-					</dependency>
-				</dependencies>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M2</version>
+				<version>3.0.0-M3</version>
 				<executions>
 					<execution>
 						<id>enforce-maven</id>
@@ -149,7 +149,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 				<executions>
 
 					<!--
@@ -209,7 +209,7 @@
 			<!-- java compiler options -->
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -219,7 +219,7 @@
 			<!-- package a single, runnable jar -->
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<id>jar-with-dependencies</id>

--- a/src/build/gon-dmg-config.template.json
+++ b/src/build/gon-dmg-config.template.json
@@ -4,7 +4,7 @@
     "password":  "",
     "provider": ""
   },
-  "notarize" :{
+  "notarize" : {
     "path": "target/EPUB-Checker.dmg",
     "bundle_id": "de.paginagmbh.epubchecker",
     "staple": true

--- a/src/build/mac-release.sh
+++ b/src/build/mac-release.sh
@@ -23,11 +23,20 @@ set -e
 # build file paths
 APP_PATH="${MVN_BUILDDIR}/${APP_NAME}.app"
 DMG_PATH="${MVN_BUILDDIR}/${APP_NAME}.dmg"
+STUB_PATH="${APP_PATH}/Contents/MacOS/universalJavaApplicationStub"
 
 
 # update App Info.plist with an additional key
 /usr/libexec/PlistBuddy -c "Add :NSAppleEventsUsageDescription string There was an error while launching ${APP_NAME_LONG}. Please click OK to display a dialog with more information or cancel and view the syslog for details." \
   "${APP_PATH}/Contents/Info.plist"
+
+
+# compile the universalJavaApplicationStub shell script to binary with 'shc'
+# https://github.com/tofi86/universalJavaApplicationStub/issues/85#issuecomment-651986038
+which shc || ( brew install shc )
+shc -r -f "${STUB_PATH}"
+rm "${STUB_PATH}" "${STUB_PATH}.x.c"
+mv "${STUB_PATH}.x" "${STUB_PATH}"
 
 
 # codesign the Mac App

--- a/src/build/mac-release.sh
+++ b/src/build/mac-release.sh
@@ -2,7 +2,7 @@
 
 # author: Tobias Fischer
 # copyright: pagina GmbH, Tübingen
-# date: 2020-03-22
+# date: 2020-07-13
 #
 # general tips about notarization
 # - http://www.zarkonnen.com/signing_notarizing_catalina

--- a/src/main/java/de/paginagmbh/epubchecker/PaginaEPUBChecker.java
+++ b/src/main/java/de/paginagmbh/epubchecker/PaginaEPUBChecker.java
@@ -19,17 +19,17 @@ import javax.swing.UIManager;
  *
  * @author      Tobias Fischer
  * @copyright   pagina GmbH, Tübingen
- * @version     2.0.0
- * @date        2020-04-05
+ * @version     2.0.1
+ * @date        2020-07-13
  */
 public class PaginaEPUBChecker {
 
 	// +++++++++++++++++++++++++ DON'T FORGET TO UPDATE EVERYTIME ++++++++++++++++++ //	
 
-	public static final String PROGRAMVERSION = "2.0.0";
-	public static final String VERSIONDATE = "05.04.2020";
-	public static final String PROGRAMRELEASE = "";	// "" or "Beta"
-	public static final String RELEASENOTES = "- Dropped support for Java 7. Supported Java versions now are 8.0.91+ up to 14.0<br/>- Notarized the Mac App for latest macOS 10.15<br/>- Improved error handling when running the program on 32bit Java<br/>- Fatal errors are now mentioned in the validation summary";
+	public static final String PROGRAMVERSION = "2.0.1";
+	public static final String VERSIONDATE = "13.07.2020";
+	public static final String PROGRAMRELEASE = "Beta";	// "" or "Beta"
+	public static final String RELEASENOTES = "- Update the official W3C EPUBCheck library to the latest release v4.2.4";
 
 	// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ //
 

--- a/src/main/java/de/paginagmbh/epubchecker/PaginaEPUBChecker.java
+++ b/src/main/java/de/paginagmbh/epubchecker/PaginaEPUBChecker.java
@@ -28,8 +28,8 @@ public class PaginaEPUBChecker {
 
 	public static final String PROGRAMVERSION = "2.0.1";
 	public static final String VERSIONDATE = "13.07.2020";
-	public static final String PROGRAMRELEASE = "Beta";	// "" or "Beta"
-	public static final String RELEASENOTES = "- Update the official W3C EPUBCheck library to the latest release v4.2.4";
+	public static final String PROGRAMRELEASE = "";	// "" or "Beta"
+	public static final String RELEASENOTES = "- Update the official W3C EPUBCheck library to the latest release v4.2.4<br/>- Improved reliability of the app under MacOS 10.15 'Catalina'";
 
 	// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ //
 


### PR DESCRIPTION
- Update the official W3C EPUBCheck library to the latest release v4.2.4 (#62)
- Improved reliability of the app under MacOS 10.15 'Catalina' (3f4c93506a7882a92a0db094ab09b0dbaf631a0f)