### PR TITLE
Release v2.0.2 via GitHub Actions

### DIFF
--- a/.github/workflows/maven-test-build.yml
+++ b/.github/workflows/maven-test-build.yml
@@ -44,7 +44,7 @@ jobs:
       run: mvn -B --show-version -Dmaven.skip.macSigning=true clean verify
 
     - name: Archive App & Jar build snapshots for Java 8
-      uses: actions/upload-artifact@v2-preview
+      uses: actions/upload-artifact@v2
       if: matrix.java == '8'
       with:
         name: App-Snapshots-Java-${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,29 +85,15 @@ jobs:
         git commit -a -m "prepare for next development iteration"
         git push "https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:development
 
-    - name: Archive Mac DiskImage distributable
-      uses: actions/upload-artifact@v2-preview
+    - name: Archive build distributables
+      uses: actions/upload-artifact@v2
       with:
-        name: Released-Mac-DiskImage
-        path: target/EPUB-Checker.dmg
-
-    - name: Archive Mac App distributable
-      uses: actions/upload-artifact@v2-preview
-      with:
-        name: Released-Mac-App
-        path: target/EPUB-Checker-*-dist-mac.zip
-
-    - name: Archive Windows App distributable
-      uses: actions/upload-artifact@v2-preview
-      with:
-        name: Released-Windows-App
-        path: target/EPUB-Checker-*-dist-win.zip
-
-    - name: Archive Linux App distributable
-      uses: actions/upload-artifact@v2-preview
-      with:
-        name: Released-Linux-App
-        path: target/EPUB-Checker-*-dist-linux.tar.gz
+        name: Signed-Apps
+        path: |
+          target/EPUB-Checker.dmg
+          target/EPUB-Checker-*-dist-mac.zip
+          target/EPUB-Checker-*-dist-win.zip
+          target/EPUB-Checker-*-dist-linux.tar.gz
 
 # TODO: Upload release-files to our primary download server
 # https://github.com/marketplace/actions/scp-files

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.paginagmbh</groupId>
 	<artifactId>EPUB-Checker</artifactId>
-	<version>2.0.1</version>
+	<version>2.0.2-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/src/build/mac-release.sh
+++ b/src/build/mac-release.sh
@@ -23,20 +23,11 @@ set -e
 # build file paths
 APP_PATH="${MVN_BUILDDIR}/${APP_NAME}.app"
 DMG_PATH="${MVN_BUILDDIR}/${APP_NAME}.dmg"
-STUB_PATH="${APP_PATH}/Contents/MacOS/universalJavaApplicationStub"
 
 
 # update App Info.plist with an additional key
 /usr/libexec/PlistBuddy -c "Add :NSAppleEventsUsageDescription string There was an error while launching ${APP_NAME_LONG}. Please click OK to display a dialog with more information or cancel and view the syslog for details." \
   "${APP_PATH}/Contents/Info.plist"
-
-
-# compile the universalJavaApplicationStub shell script to binary with 'shc'
-# https://github.com/tofi86/universalJavaApplicationStub/issues/85#issuecomment-651986038
-which shc || ( brew install shc )
-shc -r -f "${STUB_PATH}"
-rm "${STUB_PATH}" "${STUB_PATH}.x.c"
-mv "${STUB_PATH}.x" "${STUB_PATH}"
 
 
 # codesign the Mac App

--- a/src/build/mac-release.sh
+++ b/src/build/mac-release.sh
@@ -2,7 +2,7 @@
 
 # author: Tobias Fischer
 # copyright: pagina GmbH, Tübingen
-# date: 2020-07-13
+# date: 2020-03-22
 #
 # general tips about notarization
 # - http://www.zarkonnen.com/signing_notarizing_catalina

--- a/src/main/java/de/paginagmbh/epubchecker/PaginaEPUBChecker.java
+++ b/src/main/java/de/paginagmbh/epubchecker/PaginaEPUBChecker.java
@@ -19,15 +19,15 @@ import javax.swing.UIManager;
  *
  * @author      Tobias Fischer
  * @copyright   pagina GmbH, Tübingen
- * @version     2.0.1
- * @date        2020-07-13
+ * @version     2.0.2
+ * @date        2020-07-14
  */
 public class PaginaEPUBChecker {
 
 	// +++++++++++++++++++++++++ DON'T FORGET TO UPDATE EVERYTIME ++++++++++++++++++ //	
 
-	public static final String PROGRAMVERSION = "2.0.1";
-	public static final String VERSIONDATE = "13.07.2020";
+	public static final String PROGRAMVERSION = "2.0.2";
+	public static final String VERSIONDATE = "14.07.2020";
 	public static final String PROGRAMRELEASE = "";	// "" or "Beta"
 	public static final String RELEASENOTES = "- Update the official W3C EPUBCheck library to the latest release v4.2.4";
 

--- a/src/main/java/de/paginagmbh/epubchecker/PaginaEPUBChecker.java
+++ b/src/main/java/de/paginagmbh/epubchecker/PaginaEPUBChecker.java
@@ -29,7 +29,7 @@ public class PaginaEPUBChecker {
 	public static final String PROGRAMVERSION = "2.0.1";
 	public static final String VERSIONDATE = "13.07.2020";
 	public static final String PROGRAMRELEASE = "";	// "" or "Beta"
-	public static final String RELEASENOTES = "- Update the official W3C EPUBCheck library to the latest release v4.2.4<br/>- Improved reliability of the app under MacOS 10.15 'Catalina'";
+	public static final String RELEASENOTES = "- Update the official W3C EPUBCheck library to the latest release v4.2.4";
 
 	// +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ //
 


### PR DESCRIPTION
Reverted "Improved reliability of the app under MacOS 10.15 'Catalina' (3f4c935)" from 2.0.1 release (#63) because Mac Apps build on macOS 10.15 wouldn't work on macOS 10.14 (and probably lower).